### PR TITLE
Dirty attributes and exists flag (#2)

### DIFF
--- a/src/Domain/Model/DynamoDbModel.php
+++ b/src/Domain/Model/DynamoDbModel.php
@@ -183,6 +183,10 @@ abstract class DynamoDbModel extends Model
             $this->fireModelEvent('creating');
         }
 
+        if ($this->usesTimestamps()) {
+            $this->updateTimestamps();
+        }
+
         try {
             $this->client->putItem([
                 'TableName' => $this->getTable(),
@@ -261,6 +265,8 @@ abstract class DynamoDbModel extends Model
         $model->fill($item);
         // Set the model id field.
         $model->setId($id);
+        $model->exists = true;
+        $model->syncOriginal();
 
         return $model;
     }
@@ -451,6 +457,9 @@ abstract class DynamoDbModel extends Model
             $item  = $this->unmarshalItem($item);
             $model = new static($item, static::$dynamoDb);
             $model->setUnfillableAttributes($item);
+            $model->exists = true;
+            $model->syncOriginal();
+
             $results[] = $model;
         }
 


### PR DESCRIPTION
- loading a model should result in undirty attributes and a existent flagged object
- added ability to use built-in timestamp attribute
